### PR TITLE
feat: 🎸 Sync Wave追加

### DIFF
--- a/system/assets/argocd/base/alb-controller-applications.yaml
+++ b/system/assets/argocd/base/alb-controller-applications.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: aws-load-balancer-controller
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/system/assets/argocd/base/externaldns-applications.yaml
+++ b/system/assets/argocd/base/externaldns-applications.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: externaldns
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:

--- a/system/assets/argocd/base/fastapi-applications.yaml
+++ b/system/assets/argocd/base/fastapi-applications.yaml
@@ -3,6 +3,8 @@ kind: Application
 metadata:
   name: fastapi
   namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
   finalizers:
     - resources-finalizer.argocd.argoproj.io
 spec:


### PR DESCRIPTION
AWS Load Balancer Controllerを最初に起動、削除時はfastapiからにしたいので、Sync Wave導入
